### PR TITLE
feat: quick-create tags from the combo box and clear search on toggle

### DIFF
--- a/src/lib/components/pp/tag-multiselect.svelte
+++ b/src/lib/components/pp/tag-multiselect.svelte
@@ -7,6 +7,7 @@
 	import CheckIcon from '@lucide/svelte/icons/check'
 	import type { PopoverTriggerProps } from 'bits-ui'
 	import { focusAdjacentTabbable } from '$lib/utils'
+	import { quickCreateTag } from '$lib/remote/tags.remote'
 	import { tick } from 'svelte'
 
 	type Tag = { id: number; name: string; color: string; icon: string }
@@ -26,11 +27,33 @@
 	} = $props()
 
 	let open = $state(false)
+	let search = $state('')
+	let creating = $state(false)
 
 	const selectedTags = $derived(tags.filter((t) => selected.includes(t.id)))
 
+	// Offer to create a tag when the search has text that doesn't already name one.
+	const trimmedSearch = $derived(search.trim())
+	const canCreate = $derived(
+		trimmedSearch.length > 0 && !tags.some((t) => t.name.toLowerCase() === trimmedSearch.toLowerCase())
+	)
+
 	function toggle(id: number) {
 		selected = selected.includes(id) ? selected.filter((t) => t !== id) : [...selected, id]
+		// Clear the search so the next pick starts from the full list.
+		search = ''
+	}
+
+	async function create() {
+		if (!canCreate || creating) return
+		creating = true
+		try {
+			const created = await quickCreateTag(trimmedSearch)
+			if (created && !selected.includes(created.id)) selected = [...selected, created.id]
+			search = ''
+		} finally {
+			creating = false
+		}
 	}
 
 	// Tabbing out of the open palette mimics native Tab on the trigger: the palette closes and
@@ -80,12 +103,15 @@
 	>
 		<Command.Root class="flex flex-col">
 			<Command.Input
+				bind:value={search}
 				placeholder="Search Tags..."
 				onkeydown={paletteKeydown}
 				class="m-2.5 rounded-sm border border-transparent bg-bg-warm px-2.5 py-1.5 text-[13px] text-foreground placeholder:text-text-mute"
 			/>
 			<Command.List class="max-h-[260px] overflow-y-auto px-2.5 pb-2.5">
-				<Command.Empty class="px-2.5 py-3 text-center text-[12.5px] text-text-mute">No tags match.</Command.Empty>
+				{#if !canCreate}
+					<Command.Empty class="px-2.5 py-3 text-center text-[12.5px] text-text-mute">No tags match.</Command.Empty>
+				{/if}
 				{#each tags as tg (tg.id)}
 					{@const isSelected = selected.includes(tg.id)}
 					<Command.Item
@@ -100,6 +126,21 @@
 						{/if}
 					</Command.Item>
 				{/each}
+				{#if canCreate}
+					<Command.Item
+						value={search}
+						forceMount
+						onSelect={create}
+						class="flex w-full cursor-pointer items-center gap-2.5 rounded-sm px-2.5 py-2 text-left text-foreground data-selected:bg-bg-warm"
+					>
+						<span class="inline-flex size-[26px] shrink-0 items-center justify-center rounded-lg bg-bg-warm text-text-mute">
+							<PlusIcon size={14} />
+						</span>
+						<span class="flex-1 text-[13.5px]">
+							Create <span class="font-semibold">“{trimmedSearch}”</span>
+						</span>
+					</Command.Item>
+				{/if}
 			</Command.List>
 		</Command.Root>
 	</Popover.Content>

--- a/src/lib/remote/tags.remote.ts
+++ b/src/lib/remote/tags.remote.ts
@@ -4,6 +4,7 @@ import { tag, paymentsToTags } from '$lib/server/db/schema'
 import { and, eq, ne } from 'drizzle-orm'
 import { getLoggedInUser } from './auth.remote'
 import { tagUpsertSchema } from '$lib/schemas'
+import { DEFAULT_TAG_COLOR, DEFAULT_TAG_ICON } from '$lib/tag-meta'
 import * as v from 'valibot'
 import { invalid } from '@sveltejs/kit'
 
@@ -40,6 +41,30 @@ export const createOrUpdateTag = form(tagUpsertSchema, async (data, issue) => {
 	getTags().refresh()
 	return { ok: true as const }
 })
+
+// Quick-create a tag straight from the multiselect: name only, default color/icon.
+// Idempotent against the (userId, name) unique constraint — if the tag already
+// exists it's returned as-is, so the caller can just select whatever comes back.
+export const quickCreateTag = command(
+	v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(255)),
+	async (name) => {
+		const user = await getLoggedInUser()
+
+		const [existing] = await db
+			.select()
+			.from(tag)
+			.where(and(eq(tag.userId, user.id), eq(tag.name, name)))
+		if (existing) return existing
+
+		const [created] = await db
+			.insert(tag)
+			.values({ name, color: DEFAULT_TAG_COLOR, icon: DEFAULT_TAG_ICON, userId: user.id })
+			.returning()
+
+		getTags().refresh()
+		return created
+	}
+)
 
 export const deleteTag = command(v.number(), async (id) => {
 	const user = await getLoggedInUser()


### PR DESCRIPTION
## What & why

Two improvements to the payment form's tags combo box (`TagMultiSelect`), tracked on the "Payment Form's Tags Combo Box" card:

1. **Quick-create tags from the combo box.** Typing a name that doesn't already match a tag now shows a **"Create '<name>'"** row. Selecting it (click or Enter) creates the tag with the default color/icon, immediately selects it, and clears the search — no trip to the Tags page required. The create row coexists with partial matches and is keyboard-navigable (`forceMount` + `value={search}`).
2. **Clear the search after select/deselect.** `toggle()` now resets the search input so the next pick starts from the full list.

## Changes

- `src/lib/remote/tags.remote.ts` — new `quickCreateTag` command: creates a tag from just a name (default color/icon) and returns the row so the caller can select it. Idempotent against the `(userId, name)` unique constraint (returns the existing tag instead of erroring), and refreshes `getTags()`.
- `src/lib/components/pp/tag-multiselect.svelte` — bind the `Command.Input` to a `search` state; clear it on toggle; add the `canCreate`-gated "Create" row wired to `quickCreateTag`. The existing "No tags match." empty state is suppressed when the create row is shown.

## Notes for reviewers

- New tags use `DEFAULT_TAG_COLOR` / `DEFAULT_TAG_ICON` from `tag-meta.ts`; color/icon/budget can still be edited later on the Tags page.
- `quickCreateTag` follows the established remote pattern (`getLoggedInUser()` first, then `getTags().refresh()`).

## Verification

- `pnpm check` passes (0 errors, 0 warnings).
- Verified live in the browser: created a tag via the "Create" row (persisted + auto-selected + search cleared), and confirmed the search clears on both select and deselect of an existing tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
